### PR TITLE
Feat: client side encryption

### DIFF
--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -44,7 +44,7 @@ pub struct CreateClipboardPayload {
 
 #[derive(Debug, Deserialize)]
 pub struct UpdateClipboardInfoPayload {
-    pub new_text: Option<String>,
+    pub new_text: Option<Vec<u8>>,
     pub new_passwd: Option<Vec<u8>>,
     pub passwd: Option<Vec<u8>>,
 }
@@ -63,7 +63,7 @@ pub struct FullClipboardData {
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct GetClipboardsResponse {
     pub name: String,
-    pub text: String,
+    pub text: Vec<u8>,
     pub file_map: HashMap<String, String>,
     pub is_encrypted: bool,
     pub expiry: u64,

--- a/server/src/util.rs
+++ b/server/src/util.rs
@@ -1,7 +1,8 @@
 use chrono::Utc;
 use rand::rngs::OsRng;
 use rsa::{
-    pkcs1::{DecodeRsaPrivateKey, DecodeRsaPublicKey, EncodeRsaPrivateKey, EncodeRsaPublicKey},
+    pkcs1::{DecodeRsaPrivateKey, EncodeRsaPrivateKey},
+    pkcs8::{DecodePublicKey, EncodePublicKey},
     Oaep, RsaPrivateKey, RsaPublicKey,
 };
 use sha2::Sha256;
@@ -69,7 +70,7 @@ pub async fn generate_key_pair() -> Result<()> {
         .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
         .map_err(|e| Error::Unhandled(e.into()))?;
     let public_key = public_key
-        .to_pkcs1_pem(rsa::pkcs1::LineEnding::LF)
+        .to_public_key_pem(rsa::pkcs1::LineEnding::LF)
         .map_err(|e| Error::Unhandled(e.into()))?;
     tokio::fs::write(get_data_dir().join("private.pem"), private_key)
         .await
@@ -101,7 +102,7 @@ pub async fn encrypt(data: Vec<u8>) -> Vec<u8> {
     let public_key_pem = tokio::fs::read_to_string(PathBuf::new().join("data").join("public.pem"))
         .await
         .unwrap();
-    let public_key = RsaPublicKey::from_pkcs1_pem(&public_key_pem).unwrap();
+    let public_key = RsaPublicKey::from_public_key_pem(&public_key_pem).unwrap();
     let padding = Oaep::new::<Sha256>();
     public_key.encrypt(&mut OsRng, padding, &data).unwrap()
 }

--- a/server/src/web/api.rs
+++ b/server/src/web/api.rs
@@ -179,7 +179,7 @@ async fn list_clipboards(
     let clipboards = db_controller.get_clipboards().await?;
     let mut res: Vec<models::GetClipboardsResponse> = Vec::new();
     for clipboard in clipboards {
-        let text = tokio::fs::read_to_string(util::get_files_dir().join(clipboard.text_file_id))
+        let text = tokio::fs::read(util::get_files_dir().join(clipboard.text_file_id))
             .await
             .map_err(|e| Error::Unhandled(e.into()))?;
 
@@ -259,7 +259,7 @@ async fn update_clipboard(
             .open(file_path)
             .await
             .unwrap();
-        file.write_all(text_content.as_bytes()).await.unwrap();
+        file.write_all(&text_content).await.unwrap();
         file.flush().await.unwrap();
     }
 

--- a/server/tests/api/list.rs
+++ b/server/tests/api/list.rs
@@ -46,7 +46,7 @@ async fn test_list() {
         },
     );
     assert_eq!(clipboards[1].name, "clip2");
-    assert_eq!(clipboards[1].text, CLIPBOARD_TEXT);
+    assert_eq!(clipboards[1].text, CLIPBOARD_TEXT.as_bytes().to_vec());
     assert_eq!(
         clipboards[1]
             .file_map

--- a/server/tests/api/misc.rs
+++ b/server/tests/api/misc.rs
@@ -1,5 +1,5 @@
 use crate::common::init_test;
-use rsa::{pkcs1::DecodeRsaPublicKey, RsaPublicKey};
+use rsa::{pkcs8::DecodePublicKey, RsaPublicKey};
 use serial_test::serial;
 
 #[tokio::test]
@@ -14,6 +14,6 @@ async fn test_status() {
 async fn test_public_key() {
     let server = init_test().await;
     let public_key_pem = server.get("/api/publickey").await.text();
-    let public_key = RsaPublicKey::from_pkcs1_pem(&public_key_pem);
+    let public_key = RsaPublicKey::from_public_key_pem(&public_key_pem);
     assert!(public_key.is_ok());
 }

--- a/server/tests/api/update.rs
+++ b/server/tests/api/update.rs
@@ -26,7 +26,7 @@ async fn test_update() {
     .to_string();
     let info = json!({
         "passwd": ccim_server::util::encrypt(passwd_hash.into()).await,
-        "new_text": "BBBB",
+        "new_text": "BBBB".as_bytes().to_vec(),
     });
     let info = Part::text(info.to_string());
     let form = MultipartForm::new().add_part("info", info);
@@ -38,7 +38,7 @@ async fn test_update() {
 
     let body = server.get("/api/clipboards").await.text();
     let clipboards = serde_json::from_str::<Vec<GetClipboardsResponse>>(&body).unwrap();
-    assert_eq!(clipboards[0].text, "BBBB");
+    assert_eq!(clipboards[0].text, "BBBB".as_bytes().to_vec());
 }
 
 #[tokio::test]
@@ -97,7 +97,7 @@ async fn test_non_existing() {
     .to_string();
     let info = json!({
         "passwd": ccim_server::util::encrypt(passwd_hash.into()).await,
-        "new_text": "BBBB",
+        "new_text": "BBBB".as_bytes().to_vec(),
     });
     let info = Part::text(info.to_string());
     let form = MultipartForm::new().add_part("info", info);
@@ -125,7 +125,7 @@ async fn test_invalid_passwd() {
     .to_string();
     let info = json!({
         "passwd": ccim_server::util::encrypt(passwd_hash.into()).await,
-        "new_text": "BBBB",
+        "new_text": "BBBB".as_bytes().to_vec(),
     });
     let info = Part::text(info.to_string());
     let file = Part::bytes("new contents".as_bytes().to_vec()).file_name("new");

--- a/webui/src/pages/create/components/steps/AddData.tsx
+++ b/webui/src/pages/create/components/steps/AddData.tsx
@@ -42,7 +42,7 @@ const AddDataStep: React.FC<AddDataProps> = ({
     if (!selectedFiles || selectedFiles.length === 0) return;
 
     const existingFileKeys = new Set(
-      fileList.map((file) => file.name + file.size + file.lastModified)
+      fileList.map((file) => file.name + file.size + file.lastModified),
     );
     const newFiles: File[] = [];
 

--- a/webui/src/pages/create/components/util.ts
+++ b/webui/src/pages/create/components/util.ts
@@ -7,25 +7,47 @@ export interface DialogDetails {
   message: string;
 }
 
+interface Info {
+  name: string;
+  expire_after: number;
+  passwd_hash?: number[];
+}
+
+interface PasswordPayload {
+  hash: number[];
+  timestamp: number;
+}
+
 export const createClipboard = async (
   setProgress: React.Dispatch<React.SetStateAction<number | null>>,
   name: string,
   text: string,
   fileList: File[],
   expire_after: number,
-  _isEncrypted: boolean,
-  _password: string,
+  isEncrypted: boolean,
+  password: string,
 ) => {
   const formData = new FormData();
 
   if (0 < text.length) {
-    formData.append("text", text);
+    formData.append("text", isEncrypted ? await encrypt(text, password) : text);
   }
-  fileList.map((file) => formData.append("file", file));
-  const info = {
+  const encryptionPromises = fileList.map(async (file) => {
+    formData.append(
+      "file",
+      isEncrypted ? await encrypt(file, password) : file,
+      file.name,
+    );
+  });
+  await Promise.all(encryptionPromises);
+  const info: Info = {
     name,
     expire_after,
   };
+  if (isEncrypted) {
+    let passwd_hash = await preparePassword(password);
+    info["passwd_hash"] = Array.from(new Uint8Array(passwd_hash));
+  }
   formData.append("info", JSON.stringify(info));
 
   // Submit form
@@ -66,4 +88,103 @@ export const createClipboard = async (
   } finally {
     return details;
   }
+};
+
+const encrypt = async (
+  data: string | File,
+  password: string,
+): Promise<Blob> => {
+  let arrayBuffer: ArrayBuffer;
+  if (typeof data === "string") {
+    arrayBuffer = new TextEncoder().encode(data).buffer;
+  } else if (data instanceof File) {
+    arrayBuffer = await data.arrayBuffer();
+  } else {
+    throw new Error("Unsupported data type");
+  }
+  return encryptData(arrayBuffer, password);
+};
+
+const encryptData = async (
+  data: ArrayBuffer,
+  password: string,
+): Promise<Blob> => {
+  const encoder = new TextEncoder();
+  const salt = crypto.getRandomValues(new Uint8Array(16));
+  const iv = crypto.getRandomValues(new Uint8Array(12));
+  const baseKey = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(password),
+    "PBKDF2",
+    false,
+    ["deriveKey"],
+  );
+  const key = await crypto.subtle.deriveKey(
+    {
+      name: "PBKDF2",
+      salt,
+      iterations: 100000,
+      hash: "SHA-256",
+    },
+    baseKey,
+    { name: "AES-GCM", length: 256 },
+    false,
+    ["encrypt"],
+  );
+  const encryptedBuffer = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv },
+    key,
+    data,
+  );
+  const totalLength =
+    salt.byteLength + iv.byteLength + encryptedBuffer.byteLength;
+  const combined = new Uint8Array(totalLength);
+  combined.set(salt, 0);
+  combined.set(iv, salt.length);
+  combined.set(new Uint8Array(encryptedBuffer), salt.length + iv.length);
+  return new Blob([combined], { type: "application/octet-stream" });
+};
+
+const preparePassword = async (password: string): Promise<ArrayBuffer> => {
+  const passwordPayload = await preparePasswordPayload(password);
+  const publicKey = await importPublicKey();
+  return crypto.subtle.encrypt(
+    {
+      name: "RSA-OAEP",
+    },
+    publicKey,
+    new TextEncoder().encode(JSON.stringify(passwordPayload)),
+  );
+};
+
+const preparePasswordPayload = async (
+  password: string,
+): Promise<PasswordPayload> => {
+  const encoded = new TextEncoder().encode(password);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", encoded);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  const timestamp = Math.floor(Date.now() / 1000);
+  const payload = {
+    hash: hashArray,
+    timestamp,
+  };
+  return payload;
+};
+
+const importPublicKey = async (): Promise<CryptoKey> => {
+  const pemKey = await fetch("/api/publickey").then((res) => res.text());
+  const pemHeader = "-----BEGIN PUBLIC KEY-----";
+  const pemFooter = "-----END PUBLIC KEY-----";
+  const pem = pemKey
+    .replace(pemHeader, "")
+    .replace(pemFooter, "")
+    .replace(/\n/g, "");
+  const binaryDer = Uint8Array.from(atob(pem), (c) => c.charCodeAt(0));
+  return crypto.subtle.importKey(
+    "spki",
+    binaryDer.buffer,
+    { name: "RSA-OAEP", hash: "SHA-256" },
+    false,
+    ["encrypt"],
+  );
 };

--- a/webui/src/pages/home/components/ClipboardList.tsx
+++ b/webui/src/pages/home/components/ClipboardList.tsx
@@ -5,9 +5,9 @@ import React from "react";
 
 type GetClipboardResponse = {
   name: string;
-  text: string;
+  text: number[];
   file_map: { [key: string]: string };
-  isEncypted: boolean;
+  is_encrypted: boolean;
   expiry: number;
 };
 
@@ -34,13 +34,16 @@ const ClipboardList: React.FC = () => {
     const text = await response.text();
     const parsed: GetClipboardResponse[] = JSON.parse(text);
     const newClipboardEntries = parsed.map((clipboard, idx) => {
+      let decodedText = new TextDecoder().decode(
+        new Uint8Array(clipboard.text),
+      );
       return (
         <ClipboardEntry
           key={idx}
           name={clipboard.name}
-          text={clipboard.text}
+          text={decodedText}
           file_map={clipboard.file_map}
-          isEncypted={clipboard.isEncypted}
+          isEncypted={clipboard.is_encrypted}
           expiry={clipboard.expiry}
           reload={fetchAllClipboards}
         />


### PR DESCRIPTION
This PR adds client side encryption functionality to the webui.
Subsequently, the backend types have also been updated to adjust for accepting and responding in (possibly encrypted) bytes instead of plain UTF-8 strings

The public key format is also been changed, now it uses PKCS#8 for convenience 

Closes: #5 