### PR TITLE
fix(ux): created separate tab for settings section in create page

### DIFF
--- a/webui/src/pages/create/Create.tsx
+++ b/webui/src/pages/create/Create.tsx
@@ -1,43 +1,163 @@
 import React from "react";
 import Navbar from "./components/Navbar";
 import CreateClipboardStepper from "./components/CreateClipboardStepper";
-import { Box, LinearProgress } from "@mui/material";
+import { Box, LinearProgress, Paper, Tab, Tabs } from "@mui/material";
+import ContentPasteIcon from "@mui/icons-material/ContentPaste";
+import SettingsIcon from "@mui/icons-material/Settings";
+import { getRandomName } from "./components/steps/Name";
+import SettingsStep from "./components/steps/Settings";
+import { createClipboard, type DialogDetails } from "./components/util";
+import CustomDialog from "./components/CustomDialog";
+import { useNavigate } from "react-router-dom";
 
 const Create: React.FC = () => {
+  const nagivate = useNavigate();
   const [progress, setProgress] = React.useState<null | number>(null);
+  const [currentTab, setCurrentTab] = React.useState("clipboard");
+  const [showDialog, setShowDialog] = React.useState(false);
+
+  // Persistant state variables for each tab and step data
+  const [name, setName] = React.useState(getRandomName());
+  const [text, setText] = React.useState<string>("");
+  const [fileList, setFileList] = React.useState<Array<File>>([]);
+  const [expiry, setExpiry] = React.useState(5 * 60);
+  const [isEncrypted, setIsEncrypted] = React.useState(false);
+  const [password, setPassword] = React.useState<string>("");
+  const [dialogDetails, setDialogDetails] =
+    React.useState<DialogDetails | null>(null);
+  const [activeStep, setActiveStep] = React.useState(1);
+  const [currentStepperTab, setCurrentStepperTab] = React.useState("text");
+
+  const handleTabChange = (
+    _event: React.SyntheticEvent,
+    newValue: string
+  ): void => {
+    setCurrentTab(newValue);
+  };
+
+  const handleCreateClipboard = (): void => {
+    setTimeout(async () => {
+      const dialogDetails = await createClipboard(
+        setProgress,
+        name,
+        text,
+        fileList,
+        expiry,
+        isEncrypted,
+        password
+      );
+      setDialogDetails(dialogDetails);
+      setShowDialog(true);
+    }, 300);
+  };
+
+  const closeDialog = (): void => {
+    setShowDialog(false);
+    if (dialogDetails?.success) {
+      nagivate(-1);
+    } else {
+      setActiveStep(1);
+    }
+  };
+
   return (
     <>
       <Navbar />
-      <Box
-        sx={{
-          maxWidth: {
-            xs: "100%",
-            lg: "70%",
-          },
-          marginLeft: {
-            xs: "0%",
-            lg: "15%",
-          },
-        }}
-      >
-        <CreateClipboardStepper setProgress={setProgress} />
-        {progress !== null && (
-          <LinearProgress
-            variant="determinate"
-            value={progress}
+      <React.Fragment>
+        <Box
+          sx={{
+            maxWidth: {
+              xs: "100%",
+              lg: "70%",
+            },
+            marginLeft: {
+              xs: "0%",
+              lg: "15%",
+            },
+          }}
+        >
+          <Paper
             sx={{
-              maxWidth: {
-                xs: "90%",
-                lg: "100%",
+              marginY: 5,
+              paddingX: {
+                xs: 0,
+                lg: 5,
               },
-              marginLeft: {
-                xs: "5%",
-                lg: "0%",
+              paddingY: {
+                xs: 0,
+                lg: 1,
               },
             }}
-          />
-        )}
-      </Box>
+          >
+            <Tabs
+              value={currentTab}
+              onChange={handleTabChange}
+              variant="fullWidth"
+            >
+              <Tab
+                value="clipboard"
+                label="Clipboard"
+                icon={<ContentPasteIcon fontSize="small" />}
+                iconPosition="start"
+              />
+              <Tab
+                value="settings"
+                label="Settings"
+                icon={<SettingsIcon fontSize="small" />}
+                iconPosition="start"
+              />
+            </Tabs>
+
+            {currentTab === "clipboard" && (
+              <CreateClipboardStepper
+                name={name}
+                setName={setName}
+                text={text}
+                setText={setText}
+                fileList={fileList}
+                setFileList={setFileList}
+                handleCreateClipboard={handleCreateClipboard}
+                activeStep={activeStep}
+                setActiveStep={setActiveStep}
+                currentStepperTab={currentStepperTab}
+                setCurrentStepperTab={setCurrentStepperTab}
+              />
+            )}
+            {currentTab === "settings" && (
+              <SettingsStep
+                expiry={expiry}
+                setExpiry={setExpiry}
+                isEncrypted={isEncrypted}
+                setIsEncrypted={setIsEncrypted}
+                password={password}
+                setPassword={setPassword}
+              />
+            )}
+          </Paper>
+
+          {progress !== null && (
+            <LinearProgress
+              variant="determinate"
+              value={progress}
+              sx={{
+                maxWidth: {
+                  xs: "90%",
+                  lg: "100%",
+                },
+                marginLeft: {
+                  xs: "5%",
+                  lg: "0%",
+                },
+              }}
+            />
+          )}
+        </Box>
+        <CustomDialog
+          showDialog={showDialog}
+          closeDialog={closeDialog}
+          dialogDetails={dialogDetails}
+        />
+      </React.Fragment>
     </>
   );
 };

--- a/webui/src/pages/create/components/CreateClipboardStepper.tsx
+++ b/webui/src/pages/create/components/CreateClipboardStepper.tsx
@@ -4,51 +4,38 @@ import Step from "@mui/material/Step";
 import StepLabel from "@mui/material/StepLabel";
 import StepContent from "@mui/material/StepContent";
 import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
 import React from "react";
-import NameStep, { getRandomName } from "./steps/Name";
+import NameStep from "./steps/Name";
 import AddDataStep from "./steps/AddData";
-import { Paper } from "@mui/material";
-import SettingsStep from "./steps/Settings";
-import { createClipboard, type DialogDetails } from "./util";
-import CustomDialog from "./CustomDialog";
-import { useNavigate } from "react-router-dom";
 
 type CreateClipboardStepperProps = {
-  setProgress: React.Dispatch<React.SetStateAction<number | null>>;
+  name: string;
+  setName: React.Dispatch<React.SetStateAction<string>>;
+  text: string;
+  setText: React.Dispatch<React.SetStateAction<string>>;
+  fileList: File[];
+  setFileList: React.Dispatch<React.SetStateAction<File[]>>;
+  handleCreateClipboard: () => void;
+  activeStep: number;
+  setActiveStep: React.Dispatch<React.SetStateAction<number>>;
+  currentStepperTab: string;
+  setCurrentStepperTab: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const CreateClipboardStepper: React.FC<CreateClipboardStepperProps> = ({
-  setProgress,
+  name,
+  setName,
+  text,
+  setText,
+  fileList,
+  setFileList,
+  handleCreateClipboard,
+  activeStep,
+  setActiveStep,
+  currentStepperTab,
+  setCurrentStepperTab
 }) => {
-  const nagivate = useNavigate();
-  const [activeStep, setActiveStep] = React.useState(2);
-  const [showDialog, setShowDialog] = React.useState(false);
-  const [dialogDetails, setDialogDetails] =
-    React.useState<DialogDetails | null>(null);
-
-  // Persistant state variables for each step data
-  const [name, setName] = React.useState(getRandomName());
-  const [text, setText] = React.useState<string>("");
-  const [fileList, setFileList] = React.useState<Array<File>>([]);
-  const [expiry, setExpiry] = React.useState(5 * 60);
-  const [isEncrypted, setIsEncrypted] = React.useState(false);
-  const [password, setPassword] = React.useState<string>("");
-
   const steps = [
-    {
-      label: "Settings",
-      component: (
-        <SettingsStep
-          expiry={expiry}
-          setExpiry={setExpiry}
-          isEncrypted={isEncrypted}
-          setIsEncrypted={setIsEncrypted}
-          password={password}
-          setPassword={setPassword}
-        />
-      ),
-    },
     {
       label: "Choose a name",
       component: <NameStep name={name} setName={setName} />,
@@ -61,6 +48,8 @@ const CreateClipboardStepper: React.FC<CreateClipboardStepperProps> = ({
           setText={setText}
           fileList={fileList}
           setFileList={setFileList}
+          currentTab={currentStepperTab}
+          setCurrentTab={setCurrentStepperTab}
         />
       ),
     },
@@ -70,19 +59,7 @@ const CreateClipboardStepper: React.FC<CreateClipboardStepperProps> = ({
     setActiveStep((prevActiveStep) => prevActiveStep + 1);
     // All steps completed: Proceed to submit form
     if (index === steps.length - 1) {
-      setTimeout(async () => {
-        const dialogDetails = await createClipboard(
-          setProgress,
-          name,
-          text,
-          fileList,
-          expiry,
-          isEncrypted,
-          password,
-        );
-        setDialogDetails(dialogDetails);
-        setShowDialog(true);
-      }, 300);
+      handleCreateClipboard();
     }
   };
 
@@ -90,66 +67,37 @@ const CreateClipboardStepper: React.FC<CreateClipboardStepperProps> = ({
     setActiveStep((prevActiveStep) => prevActiveStep - 1);
   };
 
-  const closeDialog = () => {
-    setShowDialog(false);
-    nagivate(-1);
-  };
-
   return (
-    <React.Fragment>
-      <Paper
-        sx={{
-          marginY: 5,
-        }}
-      >
-        <Stepper
-          activeStep={activeStep}
-          orientation="vertical"
-          sx={{ marginX: 3, paddingY: 3 }}
-        >
-          {steps.map((step, index) => (
-            <Step key={step.label}>
-              <StepLabel
-                optional={
-                  index === 0 ? (
-                    <Typography variant="caption" fontStyle="italic">
-                      (Optional)
-                    </Typography>
-                  ) : null
-                }
+    <Stepper
+      activeStep={activeStep}
+      orientation="vertical"
+      sx={{ marginX: 3, paddingY: 3 }}
+    >
+      {steps.map((step, index) => (
+        <Step key={step.label}>
+          <StepLabel>{step.label}</StepLabel>
+          <StepContent>
+            {step.component}
+            <Box sx={{ mb: 2 }}>
+              <Button
+                variant="contained"
+                onClick={() => handleNext(index)}
+                sx={{ mt: 1, mr: 1 }}
               >
-                {step.label}
-              </StepLabel>
-              <StepContent>
-                {step.component}
-                <Box sx={{ mb: 2 }}>
-                  <Button
-                    variant="contained"
-                    onClick={() => handleNext(index)}
-                    sx={{ mt: 1, mr: 1 }}
-                  >
-                    {index === steps.length - 1 ? "Create" : "Next"}
-                  </Button>
-                  <Button
-                    disabled={index === 0}
-                    onClick={handleBack}
-                    sx={{ mt: 1, mr: 1 }}
-                  >
-                    Back
-                  </Button>
-                </Box>
-              </StepContent>
-            </Step>
-          ))}
-        </Stepper>
-      </Paper>
-
-      <CustomDialog
-        showDialog={showDialog}
-        closeDialog={closeDialog}
-        dialogDetails={dialogDetails}
-      />
-    </React.Fragment>
+                {index === steps.length - 1 ? "Create" : "Next"}
+              </Button>
+              <Button
+                disabled={index === 0}
+                onClick={handleBack}
+                sx={{ mt: 1, mr: 1 }}
+              >
+                Back
+              </Button>
+            </Box>
+          </StepContent>
+        </Step>
+      ))}
+    </Stepper>
   );
 };
 

--- a/webui/src/pages/create/components/steps/AddData.tsx
+++ b/webui/src/pages/create/components/steps/AddData.tsx
@@ -12,12 +12,15 @@ import {
 } from "@mui/material";
 import React from "react";
 import DeleteIcon from "@mui/icons-material/Delete";
+import { Article, Upload } from "@mui/icons-material";
 
 type AddDataProps = {
   text: string;
   setText: React.Dispatch<React.SetStateAction<string>>;
   fileList: File[];
   setFileList: React.Dispatch<React.SetStateAction<File[]>>;
+  currentTab: string;
+  setCurrentTab: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const AddDataStep: React.FC<AddDataProps> = ({
@@ -25,8 +28,9 @@ const AddDataStep: React.FC<AddDataProps> = ({
   setText,
   fileList,
   setFileList,
+  currentTab,
+  setCurrentTab,
 }) => {
-  const [currentTab, setCurrentTab] = React.useState("text");
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: string) => {
@@ -42,7 +46,7 @@ const AddDataStep: React.FC<AddDataProps> = ({
     if (!selectedFiles || selectedFiles.length === 0) return;
 
     const existingFileKeys = new Set(
-      fileList.map((file) => file.name + file.size + file.lastModified),
+      fileList.map((file) => file.name + file.size + file.lastModified)
     );
     const newFiles: File[] = [];
 
@@ -74,8 +78,18 @@ const AddDataStep: React.FC<AddDataProps> = ({
   return (
     <>
       <Tabs value={currentTab} onChange={handleTabChange} variant="fullWidth">
-        <Tab value="text" label="Text" />
-        <Tab value="files" label="Files" />
+        <Tab
+          value="text"
+          label="Text"
+          icon={<Article fontSize="small" />}
+          iconPosition="start"
+        />
+        <Tab
+          value="files"
+          label="Files"
+          icon={<Upload fontSize="small" />}
+          iconPosition="start"
+        />
       </Tabs>
 
       <Box sx={{ marginTop: 2 }}>


### PR DESCRIPTION
This PR creates a separate tab for settings section in create page. This solves the UX inconvenience as discussed in #12 

Additionally:
1. The stepper and tab states are also more "globally" managed hence they persist across tab switches
2. Closing dialog only exists create page if success, otherwise it says there to allow editing the payload

Fixes: #12