### PR TITLE
Fix: React Router client-side routing by serving index.html for non-API routes

### DIFF
--- a/server/src/web/mod.rs
+++ b/server/src/web/mod.rs
@@ -5,20 +5,12 @@ use axum::{
     routing::get,
     Router,
 };
-use tower_http::cors;
 
 pub fn app() -> Router {
     let route_apis = api::routes();
     Router::new()
-        .route("/", get(serve_frontend))
         .nest("/api", route_apis)
-        .layer(
-            cors::CorsLayer::new()
-                .allow_origin(cors::Any)
-                .allow_methods(cors::Any)
-                .allow_headers(cors::Any)
-                .expose_headers(cors::Any),
-        )
+        .fallback(get(serve_frontend))
 }
 
 async fn serve_frontend() -> impl IntoResponse {


### PR DESCRIPTION
This PR fixes #15, an issue where navigating directly to routes like `/create` in the browser would result in a 404 error because Axum was not serving `index.html` for these routes. The fix adds a catch-all route in Axum that serves the `index.html` for any request that isn't part of the API, allowing React Router to handle client-side routing.

Additionally, this PR also removes the (now) redundant CORS-allow policy