### PR TITLE
feat: Add SSE support

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tower-http",
  "tracing",
@@ -1576,6 +1577,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -234,6 +234,7 @@ dependencies = [
  "axum",
  "axum-test",
  "chrono",
+ "futures-util",
  "rand 0.8.5",
  "rsa",
  "rusqlite",
@@ -418,9 +419,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -428,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
@@ -445,36 +446,47 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1021,12 +1033,6 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkcs1"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1.41"
 rsa = "0.9.8"
 rand = "0.8.0"
 sha2 = "0.10.9"
+tokio-stream = { version = "0.1.18", features = ["sync"] }
 
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,6 +20,7 @@ rsa = "0.9.8"
 rand = "0.8.0"
 sha2 = "0.10.9"
 tokio-stream = { version = "0.1.18", features = ["sync"] }
+futures-util = "0.3.32"
 
 [dev-dependencies]
 axum-test = "17.3.0"

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -6,7 +6,7 @@ use axum::extract::FromRef;
 use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, iter::repeat_n, sync::Arc};
-use tokio::sync::Mutex;
+use tokio::sync::{broadcast, Mutex};
 
 // ----------------------- Database Related Definitions -----------------------
 
@@ -118,7 +118,7 @@ pub struct Passwd {
 #[derive(Debug, Clone, FromRef)]
 pub struct AppState {
     pub db_controller: DatabaseController,
-    pub active_clipboards: Vec<ClipboardMetadata>,
+    pub tx: broadcast::Sender<String>,
 }
 
 impl Default for AppState {
@@ -129,10 +129,62 @@ impl Default for AppState {
 
 impl AppState {
     pub fn new() -> Self {
+        let (tx, _) = broadcast::channel(100);
         Self {
             db_controller: DatabaseController::new(),
-            active_clipboards: vec![],
+            tx,
         }
+    }
+
+    pub async fn add_clipboard(&mut self, clipboard: CreateClipboardPayload) -> Result<()> {
+        self.db_controller.add_clipboard(clipboard).await?;
+        self.broadcast_clipboards().await?;
+        Ok(())
+    }
+
+    pub async fn get_clipboard(&self, clipboard_name: &String) -> Result<ClipboardData> {
+        let res = self.db_controller.get_clipboard(clipboard_name).await?;
+        Ok(res)
+    }
+
+    pub async fn delete_clipboard(
+        &mut self,
+        clipboard_name: String,
+        given_passwd: Option<Passwd>,
+    ) -> Result<DeleteClipboardResponse> {
+        let res = self
+            .db_controller
+            .delete_clipboard(clipboard_name, given_passwd)
+            .await?;
+        self.broadcast_clipboards().await?;
+        Ok(res)
+    }
+
+    pub async fn update_clipboard(
+        &mut self,
+        clipboard_name: &String,
+        info_payload: &Option<UpdateClipboardInfoPayload>,
+        delete_payload: &[String],
+        added_file_map: &HashMap<String, String>,
+    ) -> Result<UpdateClipboardResponse> {
+        let res = self
+            .db_controller
+            .update_clipboard(clipboard_name, info_payload, delete_payload, added_file_map)
+            .await?;
+        self.broadcast_clipboards().await?;
+        Ok(res)
+    }
+
+    pub async fn get_file_name(&self, file_id: &String) -> Result<String> {
+        let res = self.db_controller.get_file_name(file_id).await?;
+        Ok(res)
+    }
+
+    async fn broadcast_clipboards(&mut self) -> Result<()> {
+        let clipboards = self.db_controller.fetch_active_clipboards().await?;
+        let json = serde_json::to_string(&clipboards).unwrap_or_else(|_| "[]".into());
+        let _ = self.tx.send(json);
+        Ok(())
     }
 }
 
@@ -148,7 +200,7 @@ impl Default for DatabaseController {
 }
 
 impl DatabaseController {
-    pub fn new() -> Self {
+    fn new() -> Self {
         std::fs::create_dir_all(util::get_files_dir()).unwrap();
         let conn = Connection::open(util::get_data_dir().join("database.db3")).unwrap();
         conn.execute(
@@ -190,7 +242,7 @@ CREATE TABLE IF NOT EXISTS clipboard_files
     ///
     /// ## Returns
     /// * A `Result` containing nothing on success, or an `Error` on failure.
-    pub async fn add_clipboard(&self, clipboard: CreateClipboardPayload) -> Result<()> {
+    async fn add_clipboard(&self, clipboard: CreateClipboardPayload) -> Result<()> {
         let conn = self.db.lock().await;
         let passwd_hash = clipboard.passwd.map(|passwd| passwd.hash);
         conn.execute(
@@ -234,52 +286,6 @@ CREATE TABLE IF NOT EXISTS clipboard_files
         Ok(())
     }
 
-    /// Get all existing clipboard's metadata.
-    ///
-    /// ## Arguments
-    /// * None
-    ///
-    /// ## Returns
-    /// * A `Result` containing a `Vec` of `ClipboardMetadata` on success, or an `Error` on failure.
-    ///
-    /// ## Notes
-    /// * Invoking this function automatically calls the `clear_expired_clipboards`
-    ///   filter which removes expired clipboards details from the database as
-    ///   well as from the filesystem
-    pub async fn get_all_clipboards(&self) -> Result<Vec<ClipboardMetadata>> {
-        filter::clear_expired_clipboards(self.db.clone()).await?;
-
-        let conn = self.db.lock().await;
-
-        let mut stmt = conn
-            .prepare("SELECT clipboard_name, text_file_id, passwd_hash, expiry FROM clipboards")
-            .map_err(Error::Database)?;
-
-        let clipboard_rows = stmt
-            .query_map([], |row| {
-                Ok(ClipboardsEntry {
-                    clipboard_name: row.get(0)?,
-                    _text_file_id: row.get(1)?,
-                    passwd_hash: row.get(2)?,
-                    expiry: row.get(3)?,
-                })
-            })
-            .map_err(Error::Database)?;
-
-        let mut clipboards: Vec<ClipboardMetadata> = Vec::new();
-
-        for clipboard_row in clipboard_rows.filter_map(|row| row.ok()) {
-            let clipboard = ClipboardMetadata {
-                name: clipboard_row.clipboard_name,
-                is_encrypted: clipboard_row.passwd_hash.is_some(),
-                expiry: clipboard_row.expiry,
-            };
-            clipboards.push(clipboard);
-        }
-
-        Ok(clipboards)
-    }
-
     /// Get data for a particular clipboard.
     ///
     /// ## Arguments
@@ -292,7 +298,7 @@ CREATE TABLE IF NOT EXISTS clipboard_files
     /// * The response only contains the UUIDs of the files where the data is
     ///   located on the disk. The caller must ensure to read the contents
     ///   themselves.
-    pub async fn get_clipboard(&self, clipboard_name: &String) -> Result<ClipboardData> {
+    async fn get_clipboard(&self, clipboard_name: &String) -> Result<ClipboardData> {
         self.ensure_clipboard_exists(clipboard_name).await?;
 
         let conn = self.db.lock().await;
@@ -337,7 +343,7 @@ CREATE TABLE IF NOT EXISTS clipboard_files
     ///
     /// ## Returns
     /// * A `Result` containing the `DeleteClipboardResponse` on success, or an `Error` on failure.
-    pub async fn delete_clipboard(
+    async fn delete_clipboard(
         &self,
         clipboard_name: String,
         given_passwd: Option<Passwd>,
@@ -421,7 +427,7 @@ CREATE TABLE IF NOT EXISTS clipboard_files
     /// * For example while specifying a `new_text` this function only returns
     ///   the `text_file_id` for the filesystem path of the stored text content.
     ///   The caller must ensure to update it in the filesystem themself.
-    pub async fn update_clipboard(
+    async fn update_clipboard(
         &self,
         clipboard_name: &String,
         info_payload: &Option<UpdateClipboardInfoPayload>,
@@ -495,6 +501,24 @@ CREATE TABLE IF NOT EXISTS clipboard_files
         Ok(res)
     }
 
+    /// Get the real file name mapped to the given file id
+    ///
+    /// ## Arguments
+    /// * `file_id` - The file id, whose name is to be retrieved.
+    ///
+    /// ## Returns
+    /// * A `Result` containing the `String` (the file name), or an `Error` on failure.
+    async fn get_file_name(&self, file_id: &String) -> Result<String> {
+        let conn = self.db.lock().await;
+        let mut stmt = conn
+            .prepare("SELECT file_name from clipboard_files WHERE file_id = ?")
+            .map_err(Error::Database)?;
+        let file_name = stmt
+            .query_row([file_id], |row| row.get::<_, String>(0))
+            .map_err(|_| Error::FileDoesNotExist)?;
+        Ok(file_name)
+    }
+
     /// Updates selective fields for the associated clipboard.
     ///
     /// ## Updatable details fields
@@ -538,24 +562,6 @@ CREATE TABLE IF NOT EXISTS clipboard_files
         Ok(res)
     }
 
-    /// Get the real file name mapped to the given file id
-    ///
-    /// ## Arguments
-    /// * `file_id` - The file id, whose name is to be retrieved.
-    ///
-    /// ## Returns
-    /// * A `Result` containing the `String` (the file name), or an `Error` on failure.
-    pub async fn get_file_name(&self, file_id: &String) -> Result<String> {
-        let conn = self.db.lock().await;
-        let mut stmt = conn
-            .prepare("SELECT file_name from clipboard_files WHERE file_id = ?")
-            .map_err(Error::Database)?;
-        let file_name = stmt
-            .query_row([file_id], |row| row.get::<_, String>(0))
-            .map_err(|_| Error::FileDoesNotExist)?;
-        Ok(file_name)
-    }
-
     async fn ensure_clipboard_exists(&self, clipboard_name: &String) -> Result<()> {
         let conn = self.db.lock().await;
         let mut stmt = conn
@@ -569,5 +575,51 @@ CREATE TABLE IF NOT EXISTS clipboard_files
             return Err(Error::ClipboardDoesNotExist);
         }
         Ok(())
+    }
+
+    /// Get all existing clipboard's metadata.
+    ///
+    /// ## Arguments
+    /// * None
+    ///
+    /// ## Returns
+    /// * A `Result` containing a `Vec` of `ClipboardMetadata` on success, or an `Error` on failure.
+    ///
+    /// ## Notes
+    /// * Invoking this function automatically calls the `clear_expired_clipboards`
+    ///   filter which removes expired clipboards details from the database as
+    ///   well as from the filesystem
+    pub async fn fetch_active_clipboards(&self) -> Result<Vec<ClipboardMetadata>> {
+        filter::clear_expired_clipboards(self.db.clone()).await?;
+
+        let conn = self.db.lock().await;
+
+        let mut stmt = conn
+            .prepare("SELECT clipboard_name, text_file_id, passwd_hash, expiry FROM clipboards")
+            .map_err(Error::Database)?;
+
+        let clipboard_rows = stmt
+            .query_map([], |row| {
+                Ok(ClipboardsEntry {
+                    clipboard_name: row.get(0)?,
+                    _text_file_id: row.get(1)?,
+                    passwd_hash: row.get(2)?,
+                    expiry: row.get(3)?,
+                })
+            })
+            .map_err(Error::Database)?;
+
+        let mut clipboards: Vec<ClipboardMetadata> = Vec::new();
+
+        for clipboard_row in clipboard_rows.filter_map(|row| row.ok()) {
+            let clipboard = ClipboardMetadata {
+                name: clipboard_row.clipboard_name,
+                is_encrypted: clipboard_row.passwd_hash.is_some(),
+                expiry: clipboard_row.expiry,
+            };
+            clipboards.push(clipboard);
+        }
+
+        Ok(clipboards)
     }
 }

--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -59,7 +59,7 @@ pub struct FullClipboardData {
     pub expiry: u64,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClipboardMetadata {
     pub name: String,
     pub is_encrypted: bool,
@@ -114,6 +114,27 @@ pub struct Passwd {
 }
 
 // ----------------------------------------------------------------------------
+
+#[derive(Debug, Clone, FromRef)]
+pub struct AppState {
+    pub db_controller: DatabaseController,
+    pub active_clipboards: Vec<ClipboardMetadata>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl AppState {
+    pub fn new() -> Self {
+        Self {
+            db_controller: DatabaseController::new(),
+            active_clipboards: vec![],
+        }
+    }
+}
 
 #[derive(Debug, Clone, FromRef)]
 pub struct DatabaseController {

--- a/server/src/web/api.rs
+++ b/server/src/web/api.rs
@@ -30,7 +30,7 @@ const ADDITIONAL_BUFFER_SIZE: usize = 1;
 
 /// Returns the API router with all defined HTTP routes.
 pub fn routes() -> Router {
-    let db_controller = models::DatabaseController::new();
+    let app_state = models::AppState::new();
     Router::new()
         .route("/status", get(status))
         .route("/publickey", get(public_key))
@@ -45,7 +45,7 @@ pub fn routes() -> Router {
                 .delete(delete_clipboard),
         )
         .route("/clipboards/file/{id}", get(download_file))
-        .with_state(db_controller)
+        .with_state(app_state)
         .layer(DefaultBodyLimit::disable())
         .layer(RequestBodyLimitLayer::new(
             (FILES_MAX_SIZE + TEXT_MAX_SIZE + ADDITIONAL_BUFFER_SIZE) * 1024 * 1024,
@@ -67,7 +67,7 @@ async fn public_key() -> Result<String> {
 
 /// Creates a new clipboard with optional text, files, and metadata sent via multipart form data.
 async fn create_clipboard(
-    State(db_controller): State<models::DatabaseController>,
+    State(state): State<models::AppState>,
     mut multipart: Multipart,
 ) -> Result<StatusCode> {
     let mut file_map: HashMap<String, String> = HashMap::new(); // Maps the actual file name to its uuid name in the filesystem
@@ -166,7 +166,7 @@ async fn create_clipboard(
     };
 
     // Attempt to add to database
-    match db_controller.add_clipboard(clipboard).await {
+    match state.db_controller.add_clipboard(clipboard).await {
         Ok(_) => Ok(()),
         Err(e) => {
             // Cleanup stored text/file(s) since this request will be rejected
@@ -180,9 +180,9 @@ async fn create_clipboard(
 
 /// Returns a list of all stored clipboards (and their metadata).
 async fn get_all_clipboards(
-    State(db_controller): State<models::DatabaseController>,
+    State(state): State<models::AppState>,
 ) -> Result<(StatusCode, Json<Vec<models::ClipboardMetadata>>)> {
-    let res = db_controller.get_all_clipboards().await?;
+    let res = state.db_controller.get_all_clipboards().await?;
 
     if res.is_empty() {
         Ok((StatusCode::NO_CONTENT, Json(res)))
@@ -192,10 +192,10 @@ async fn get_all_clipboards(
 }
 
 async fn get_clipboard(
-    State(db_controller): State<models::DatabaseController>,
+    State(state): State<models::AppState>,
     Path(name): Path<String>,
 ) -> Result<(StatusCode, Json<models::ClipboardDataResponse>)> {
-    let clipboard_data = db_controller.get_clipboard(&name).await?;
+    let clipboard_data = state.db_controller.get_clipboard(&name).await?;
 
     let text = tokio::fs::read(util::get_files_dir().join(clipboard_data.text_file_id))
         .await
@@ -215,7 +215,7 @@ async fn get_clipboard(
 
 /// Updates an existing clipboard with new text, added files, or removed files.
 async fn update_clipboard(
-    State(db_controller): State<models::DatabaseController>,
+    State(state): State<models::AppState>,
     Path(name): Path<String>,
     mut multipart: Multipart,
 ) -> Result<StatusCode> {
@@ -251,7 +251,8 @@ async fn update_clipboard(
         }
     }
 
-    let res = match db_controller
+    let res = match state
+        .db_controller
         .update_clipboard(&name, &new_info, &deleted_files, &added_file_map)
         .await
     {
@@ -287,7 +288,7 @@ async fn update_clipboard(
 
 /// Deletes a clipboard and all associated files from the system.
 async fn delete_clipboard(
-    State(db_controller): State<models::DatabaseController>,
+    State(state): State<models::AppState>,
     Path(name): Path<String>,
     mut multipart: Multipart,
 ) -> Result<StatusCode> {
@@ -301,18 +302,18 @@ async fn delete_clipboard(
             passwd = Some(_passwd);
         }
     }
-    let to_be_deleted = db_controller.delete_clipboard(name, passwd).await?;
+    let to_be_deleted = state.db_controller.delete_clipboard(name, passwd).await?;
     util::cleanup_files(to_be_deleted.text_file_id, to_be_deleted.file_ids).await;
     Ok(StatusCode::NO_CONTENT)
 }
 
 /// Streams a file to the client by its ID, if it exists.
 async fn download_file(
-    State(db_controller): State<models::DatabaseController>,
+    State(state): State<models::AppState>,
     Path(id): Path<String>,
 ) -> Result<Response> {
     // TODO : Add password hash checks (do we need this)
-    let file_name = db_controller.get_file_name(&id).await?;
+    let file_name = state.db_controller.get_file_name(&id).await?;
     let file_path = util::get_files_dir().join(id);
     if !file_path.exists() {
         return Ok(Response::builder()

--- a/server/src/web/api.rs
+++ b/server/src/web/api.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, convert::Infallible};
 
 use axum::{
     body::Body,
@@ -7,7 +7,7 @@ use axum::{
         header::{CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE},
         StatusCode,
     },
-    response::Response,
+    response::{sse::Event, Response, Sse},
     routing::{get, post},
     Json, Router,
 };
@@ -16,6 +16,7 @@ use tokio::{
     fs::{File, OpenOptions},
     io::AsyncWriteExt,
 };
+use tokio_stream::{wrappers::BroadcastStream, Stream, StreamExt};
 use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::{
@@ -34,10 +35,7 @@ pub fn routes() -> Router {
     Router::new()
         .route("/status", get(status))
         .route("/publickey", get(public_key))
-        .route(
-            "/clipboards",
-            post(create_clipboard).get(get_all_clipboards),
-        )
+        .route("/clipboards", post(create_clipboard).get(list_clipboards))
         .route(
             "/clipboards/{name}",
             get(get_clipboard)
@@ -67,7 +65,7 @@ async fn public_key() -> Result<String> {
 
 /// Creates a new clipboard with optional text, files, and metadata sent via multipart form data.
 async fn create_clipboard(
-    State(state): State<models::AppState>,
+    State(mut state): State<models::AppState>,
     mut multipart: Multipart,
 ) -> Result<StatusCode> {
     let mut file_map: HashMap<String, String> = HashMap::new(); // Maps the actual file name to its uuid name in the filesystem
@@ -166,7 +164,7 @@ async fn create_clipboard(
     };
 
     // Attempt to add to database
-    match state.db_controller.add_clipboard(clipboard).await {
+    match state.add_clipboard(clipboard).await {
         Ok(_) => Ok(()),
         Err(e) => {
             // Cleanup stored text/file(s) since this request will be rejected
@@ -178,24 +176,36 @@ async fn create_clipboard(
     Ok(StatusCode::CREATED)
 }
 
-/// Returns a list of all stored clipboards (and their metadata).
-async fn get_all_clipboards(
+/// Returns a list of all active clipboards (and their metadata).
+async fn list_clipboards(
     State(state): State<models::AppState>,
-) -> Result<(StatusCode, Json<Vec<models::ClipboardMetadata>>)> {
-    let res = state.db_controller.get_all_clipboards().await?;
+) -> Sse<impl Stream<Item = std::result::Result<Event, Infallible>>> {
+    let initial_state = state
+        .db_controller
+        .fetch_active_clipboards()
+        .await
+        .unwrap_or_default();
+    let initial_stream = futures_util::stream::once(async move {
+        let json = serde_json::to_string(&initial_state).unwrap_or_else(|_| "[]".into());
+        Ok(Event::default().data(json))
+    });
 
-    if res.is_empty() {
-        Ok((StatusCode::NO_CONTENT, Json(res)))
-    } else {
-        Ok((StatusCode::OK, Json(res)))
-    }
+    let rx = state.tx.subscribe();
+    let updates = BroadcastStream::new(rx).filter_map(|res| match res {
+        Ok(json) => Some(Ok(Event::default().data(json))),
+        Err(_) => None,
+    });
+
+    let stream = initial_stream.chain(updates);
+
+    Sse::new(stream)
 }
 
 async fn get_clipboard(
     State(state): State<models::AppState>,
     Path(name): Path<String>,
 ) -> Result<(StatusCode, Json<models::ClipboardDataResponse>)> {
-    let clipboard_data = state.db_controller.get_clipboard(&name).await?;
+    let clipboard_data = state.get_clipboard(&name).await?;
 
     let text = tokio::fs::read(util::get_files_dir().join(clipboard_data.text_file_id))
         .await
@@ -215,7 +225,7 @@ async fn get_clipboard(
 
 /// Updates an existing clipboard with new text, added files, or removed files.
 async fn update_clipboard(
-    State(state): State<models::AppState>,
+    State(mut state): State<models::AppState>,
     Path(name): Path<String>,
     mut multipart: Multipart,
 ) -> Result<StatusCode> {
@@ -252,7 +262,6 @@ async fn update_clipboard(
     }
 
     let res = match state
-        .db_controller
         .update_clipboard(&name, &new_info, &deleted_files, &added_file_map)
         .await
     {
@@ -288,7 +297,7 @@ async fn update_clipboard(
 
 /// Deletes a clipboard and all associated files from the system.
 async fn delete_clipboard(
-    State(state): State<models::AppState>,
+    State(mut state): State<models::AppState>,
     Path(name): Path<String>,
     mut multipart: Multipart,
 ) -> Result<StatusCode> {
@@ -302,7 +311,7 @@ async fn delete_clipboard(
             passwd = Some(_passwd);
         }
     }
-    let to_be_deleted = state.db_controller.delete_clipboard(name, passwd).await?;
+    let to_be_deleted = state.delete_clipboard(name, passwd).await?;
     util::cleanup_files(to_be_deleted.text_file_id, to_be_deleted.file_ids).await;
     Ok(StatusCode::NO_CONTENT)
 }
@@ -313,7 +322,7 @@ async fn download_file(
     Path(id): Path<String>,
 ) -> Result<Response> {
     // TODO : Add password hash checks (do we need this)
-    let file_name = state.db_controller.get_file_name(&id).await?;
+    let file_name = state.get_file_name(&id).await?;
     let file_path = util::get_files_dir().join(id);
     if !file_path.exists() {
         return Ok(Response::builder()

--- a/webui/src/context/ClipboardContext.tsx
+++ b/webui/src/context/ClipboardContext.tsx
@@ -32,23 +32,27 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
   >([]);
   const [loading, setLoading] = React.useState(true);
 
-  const fetchClipboards = React.useCallback(async (silent = false) => {
-    if (!silent) setLoading(true);
-    const response = await fetch("/api/clipboards");
-    if (response.status === 204) {
-      setClipboardList([]);
-      if (!silent) setLoading(false);
-      return;
-    }
-    if (response.status !== 200) {
-      console.error("Failed to get all clipboards");
-      if (!silent) setLoading(false);
-      return;
-    }
-    const text = await response.text();
-    const parsed: ClipboardMetadata[] = JSON.parse(text);
-    setClipboardList(parsed);
-    if (!silent) setLoading(false);
+  React.useEffect(() => {
+    setLoading(true);
+    const eventSource = new EventSource("/api/clipboards");
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data: ClipboardMetadata[] = JSON.parse(event.data);
+        setClipboardList(data);
+        setLoading(false);
+      } catch (err) {
+        console.error("Failed to parse SSE data", err);
+      }
+    };
+
+    eventSource.onerror = (err) => {
+      console.error("SSE connection error", err);
+    };
+
+    return () => {
+      eventSource.close();
+    };
   }, []);
 
   const fetchClipboardData = React.useCallback(async (name: string) => {
@@ -69,7 +73,7 @@ export const ClipboardProvider: React.FC<ClipboardProviderProps> = ({
       value={{
         clipboardList,
         setClipboardList,
-        fetchClipboards,
+        fetchClipboards: async () => { }, // Kept for type compatibility if needed elsewhere, but does nothing
         loading,
         fetchClipboardData
       }}


### PR DESCRIPTION
This PR utilises the GET API refactor from #28 and builds an SSE layer upon it.

Using an SSE response instead of regular HTTP like before allows us to have real-time updates in the clipboard list.