### PR TITLE
fix: create fields on clipboard create

### DIFF
--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -3,7 +3,7 @@ import { Toolbar, CssBaseline, useMediaQuery, Box } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import MyDrawer from "./DrawerContent";
 import MyAppbar from "./MyAppbar";
-import { Route, Routes } from "react-router-dom";
+import { Route, Routes, useLocation } from "react-router-dom";
 import Create from "./pages/create/Create";
 import Clip from "./pages/clip/Clip";
 import Home from "./pages/home/Home";
@@ -28,6 +28,7 @@ const App = () => {
   const { loading } = useClipboard()!;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
+  const location = useLocation();
 
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
@@ -71,9 +72,9 @@ const App = () => {
               animation: `${fadeIn} 0.6s ease-out`,
             }}
           >
-            <Routes>
+            <Routes location={location}>
               <Route path="/" element={<Home />} />
-              <Route path="/create" element={<Create />} />
+              <Route path="/create" element={<Create key={location.key} />} />
               <Route path="/clip/:clipboardName" element={<Clip />} />
             </Routes>
           </Box>

--- a/webui/src/pages/create/Create.tsx
+++ b/webui/src/pages/create/Create.tsx
@@ -8,6 +8,7 @@ import SettingsStep from "./components/steps/Settings";
 import { createClipboard, type DialogDetails } from "./components/util";
 import CustomDialog from "./components/CustomDialog";
 import { useClipboard } from "../../context/ClipboardContext";
+import { useNavigate } from "react-router-dom";
 
 const Create: React.FC = () => {
   const [progress, setProgress] = React.useState<null | number>(null);
@@ -26,6 +27,7 @@ const Create: React.FC = () => {
   const [activeStep, setActiveStep] = React.useState(1);
   const [currentStepperTab, setCurrentStepperTab] = React.useState("text");
   const { fetchClipboards } = useClipboard()!;
+  const navigate = useNavigate();
 
   const handleTabChange = (
     _event: React.SyntheticEvent,
@@ -52,8 +54,8 @@ const Create: React.FC = () => {
 
   const closeDialog = (): void => {
     setShowDialog(false);
-    setActiveStep(1);
     fetchClipboards();
+    navigate("/create");
   };
 
   return (


### PR DESCRIPTION
Fixes: #32 

Reload the /create page on successful clipboard creation, this forces the fields to be "clean" after clipboard is created and ready for new creation