### PR TITLE
fix: truncate text file on update

### DIFF
--- a/server/src/web/api.rs
+++ b/server/src/web/api.rs
@@ -280,6 +280,7 @@ async fn update_clipboard(
         let file_path = util::get_files_dir().join(text_file_id);
         let mut file = OpenOptions::new()
             .write(true)
+            .truncate(true)
             .open(file_path)
             .await
             .unwrap();


### PR DESCRIPTION
Fixes: #34 

On updating, the original text content should be entirely replaced by new content, instead of in-place replacement. Fixed by using `.truncate(true)`.