### PR TITLE
feat: add SSE update

### DIFF
--- a/server/src/models.rs
+++ b/server/src/models.rs
@@ -6,7 +6,7 @@ use axum::extract::FromRef;
 use rusqlite::{params, params_from_iter, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, iter::repeat_n, sync::Arc};
-use tokio::sync::{broadcast, Mutex};
+use tokio::sync::{broadcast, Mutex, RwLock};
 
 // ----------------------- Database Related Definitions -----------------------
 
@@ -74,13 +74,13 @@ pub struct ClipboardData {
 }
 
 /// Actual response from the API.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClipboardDataResponse {
     pub text: Vec<u8>,
     pub files: Vec<FileInfo>,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct FileInfo {
     pub name: String,
     pub id: String,
@@ -118,7 +118,8 @@ pub struct Passwd {
 #[derive(Debug, Clone, FromRef)]
 pub struct AppState {
     pub db_controller: DatabaseController,
-    pub tx: broadcast::Sender<String>,
+    pub active_list_tx: broadcast::Sender<String>,
+    pub clipboard_txs: Arc<RwLock<HashMap<String, broadcast::Sender<ClipboardDataResponse>>>>,
 }
 
 impl Default for AppState {
@@ -129,10 +130,11 @@ impl Default for AppState {
 
 impl AppState {
     pub fn new() -> Self {
-        let (tx, _) = broadcast::channel(100);
+        let (active_list_tx, _) = broadcast::channel(100);
         Self {
             db_controller: DatabaseController::new(),
-            tx,
+            active_list_tx,
+            clipboard_txs: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -154,9 +156,14 @@ impl AppState {
     ) -> Result<DeleteClipboardResponse> {
         let res = self
             .db_controller
-            .delete_clipboard(clipboard_name, given_passwd)
+            .delete_clipboard(clipboard_name.clone(), given_passwd)
             .await?;
         self.broadcast_clipboards().await?;
+        // Remove broadcast channel for this clipboard
+        {
+            let mut map = self.clipboard_txs.write().await;
+            map.remove(&clipboard_name);
+        }
         Ok(res)
     }
 
@@ -171,7 +178,6 @@ impl AppState {
             .db_controller
             .update_clipboard(clipboard_name, info_payload, delete_payload, added_file_map)
             .await?;
-        self.broadcast_clipboards().await?;
         Ok(res)
     }
 
@@ -180,10 +186,27 @@ impl AppState {
         Ok(res)
     }
 
+    pub async fn broadcast_clipboard_update(
+        &self,
+        clipboard_name: &str,
+        clipboard_data: ClipboardDataResponse,
+    ) -> Result<()> {
+        let mut map = self.clipboard_txs.write().await;
+        if let Some(tx) = map.get(clipboard_name) {
+            let _ = tx.send(clipboard_data);
+
+            // Cleanup if no subscribers left
+            if tx.receiver_count() == 0 {
+                map.remove(clipboard_name);
+            }
+        };
+        Ok(())
+    }
+
     async fn broadcast_clipboards(&mut self) -> Result<()> {
         let clipboards = self.db_controller.fetch_active_clipboards().await?;
         let json = serde_json::to_string(&clipboards).unwrap_or_else(|_| "[]".into());
-        let _ = self.tx.send(json);
+        let _ = self.active_list_tx.send(json);
         Ok(())
     }
 }

--- a/server/src/web/api.rs
+++ b/server/src/web/api.rs
@@ -15,14 +15,14 @@ use chrono::Utc;
 use tokio::{
     fs::{File, OpenOptions},
     io::AsyncWriteExt,
+    sync::broadcast,
 };
 use tokio_stream::{wrappers::BroadcastStream, Stream, StreamExt};
 use tower_http::limit::RequestBodyLimitLayer;
 
 use crate::{
     error::{Error, Result},
-    models::{self, ClipboardDataResponse},
-    util,
+    models, util,
 };
 
 const FILES_MAX_SIZE: usize = 100;
@@ -43,6 +43,7 @@ pub fn routes() -> Router {
                 .delete(delete_clipboard),
         )
         .route("/clipboards/file/{id}", get(download_file))
+        .route("/clipboards/{name}/events", get(clipboard_events))
         .with_state(app_state)
         .layer(DefaultBodyLimit::disable())
         .layer(RequestBodyLimitLayer::new(
@@ -190,7 +191,7 @@ async fn list_clipboards(
         Ok(Event::default().data(json))
     });
 
-    let rx = state.tx.subscribe();
+    let rx = state.active_list_tx.subscribe();
     let updates = BroadcastStream::new(rx).filter_map(|res| match res {
         Ok(json) => Some(Ok(Event::default().data(json))),
         Err(_) => None,
@@ -206,7 +207,13 @@ async fn get_clipboard(
     Path(name): Path<String>,
 ) -> Result<(StatusCode, Json<models::ClipboardDataResponse>)> {
     let clipboard_data = state.get_clipboard(&name).await?;
+    let clipboard_data = read_clipboard_from_disk(clipboard_data).await?;
+    Ok((StatusCode::OK, Json(clipboard_data)))
+}
 
+async fn read_clipboard_from_disk(
+    clipboard_data: models::ClipboardData,
+) -> Result<models::ClipboardDataResponse> {
     let text = tokio::fs::read(util::get_files_dir().join(clipboard_data.text_file_id))
         .await
         .map_err(|e| Error::Unhandled(e.into()))?;
@@ -220,7 +227,7 @@ async fn get_clipboard(
         files.push(models::FileInfo { name, id, size });
     }
 
-    Ok((StatusCode::OK, Json(ClipboardDataResponse { text, files })))
+    Ok(models::ClipboardDataResponse { text, files })
 }
 
 /// Updates an existing clipboard with new text, added files, or removed files.
@@ -293,6 +300,17 @@ async fn update_clipboard(
         util::delete_file(file_id).await;
     }
 
+    // NOTE: This needs to be called in the API handler instead of the state
+    // impl functions like update_clipboard(), because the current flow is:
+    // update_clipboard() -> write to disk
+    // If broadcast is called at the end of update_clipboard() then we would be
+    // broadcasting data which is not yet written/flushed to the disk.
+    let clipboard_data = state.get_clipboard(&name).await?;
+    let clipboard_data = read_clipboard_from_disk(clipboard_data).await?;
+    state
+        .broadcast_clipboard_update(&name, clipboard_data)
+        .await?;
+
     Ok(StatusCode::OK)
 }
 
@@ -344,4 +362,38 @@ async fn download_file(
         )
         .body(body)
         .unwrap())
+}
+
+async fn clipboard_events(
+    State(state): State<models::AppState>,
+    Path(name): Path<String>,
+) -> Sse<impl Stream<Item = std::result::Result<Event, Infallible>>> {
+    let tx = {
+        let map = state.clipboard_txs.read().await;
+        map.get(&name).cloned()
+    };
+
+    let tx = if let Some(tx) = tx {
+        tx
+    } else {
+        let mut map = state.clipboard_txs.write().await;
+        map.entry(name.clone())
+            .or_insert_with(|| {
+                let (tx, _) = broadcast::channel(100);
+                tx
+            })
+            .clone()
+    };
+
+    let rx = tx.subscribe();
+
+    let stream = BroadcastStream::new(rx).filter_map(|res| match res {
+        Ok(clipboard_data) => match serde_json::to_string(&clipboard_data) {
+            Ok(json) => Some(Ok(Event::default().data(json))),
+            Err(_) => None,
+        },
+        Err(_) => None,
+    });
+
+    Sse::new(stream)
 }

--- a/webui/src/pages/clip/Clip.tsx
+++ b/webui/src/pages/clip/Clip.tsx
@@ -285,6 +285,37 @@ const Clip: React.FC = () => {
     loadData();
   }, [clipboardName, fetchClipboardData]);
 
+  // SSE for real-time updates of the selected clipboard
+  React.useEffect(() => {
+    if (!clipboardName) return;
+
+    const eventSource = new EventSource(`/api/clipboards/${clipboardName}/events`);
+
+    eventSource.onmessage = (event) => {
+      try {
+        const data = JSON.parse(event.data);
+        setDetailedData((prev) => {
+          if (!prev) return null;
+          return {
+            ...prev,
+            text: data.text,
+            files: data.files,
+          };
+        });
+      } catch (err) {
+        console.error("Failed to parse clipboard SSE data", err);
+      }
+    };
+
+    eventSource.onerror = (err) => {
+      console.error("Clipboard SSE connection error", err);
+    };
+
+    return () => {
+      eventSource.close();
+    };
+  }, [clipboardName]);
+
   React.useEffect(() => {
     const extractData = async () => {
       if (!clipboard) return;


### PR DESCRIPTION
Closes: #36 

Use dedicated broadcast channels per clipboard to handle SSE events and deliver real-time updates to clipboard content